### PR TITLE
Fix small mistakes in study def

### DIFF
--- a/analysis/study_definition.py
+++ b/analysis/study_definition.py
@@ -421,6 +421,7 @@ study = StudyDefinition(
         ),
     ),
     # Blood pressure
+    # filtering on >0 as missing values are returned as 0
     bp=patients.categorised_as(
         {
             "0": "DEFAULT",
@@ -560,7 +561,7 @@ study = StudyDefinition(
                 diabetes AND hba1c_category = "2"
                 """,
             "3": """
-                diabetes AND hba1c_category = "3"
+                diabetes AND hba1c_category = "0"
                 """
         }, return_expectations={
                                 "category": {
@@ -600,7 +601,7 @@ study = StudyDefinition(
         returning="binary_flag",
         on_or_before="index_date",
         find_last_match_in_period=True,
-        include_date_of_match=True,  # generates kidney_transplant_date
+        include_date_of_match=True,  # generates dialysis_date
         date_format="YYYY-MM-DD",
     ),
     # Kidney transplant

--- a/analysis/study_definition_wave1.py
+++ b/analysis/study_definition_wave1.py
@@ -895,18 +895,7 @@ study = StudyDefinition(
     ),
     # OUTCOMES
     # Patients with ONS-registered death
-    died_ons_covid_flag_any=patients.with_these_codes_on_death_certificate(
-        covid_codelist,  # imported from codelists.py
-        returning="binary_flag",
-        between=["index_date", end_date],
-        match_only_underlying_cause=False,  # boolean for indicating if filters
-        # results to only specified cause of death
-        return_expectations={
-            "rate": "exponential_increase",
-            "incidence": 0.05,
-        },
-    ),
-    died_ons_covid_flag_any_date=patients.with_these_codes_on_death_certificate(
+    died_ons_covid_any_date=patients.with_these_codes_on_death_certificate(
         covid_codelist,  # imported from codelists.py
         returning="date_of_death",
         between=["index_date", end_date],

--- a/analysis/study_definition_wave1.py
+++ b/analysis/study_definition_wave1.py
@@ -420,6 +420,7 @@ study = StudyDefinition(
         ),
     ),
     # Blood pressure
+    # filtering on >0 as missing values are returned as 0
     bp=patients.categorised_as(
         {
             "0": "DEFAULT",
@@ -559,7 +560,7 @@ study = StudyDefinition(
                 diabetes AND hba1c_category = "2"
                 """,
             "3": """
-                diabetes AND hba1c_category = "3"
+                diabetes AND hba1c_category = "0"
                 """
         }, return_expectations={
                                 "category": {
@@ -699,7 +700,7 @@ study = StudyDefinition(
     # egfr<60 BUT since first rule is >45, we're not sure it actually is >45.
     # Restricting to those not '>', '>=', '~' or '=' (like is done for category
     # 5) is therefore not enough, and we need to be stricter by limiting to
-    # '='. The only comparator that can be used AND fullfils both rules, 
+    # '='. The only comparator that can be used AND fullfils both rules,
     # is '='.
     egfr_category=patients.categorised_as(
         {

--- a/analysis/study_definition_wave2.py
+++ b/analysis/study_definition_wave2.py
@@ -895,18 +895,7 @@ study = StudyDefinition(
     ),
     # OUTCOMES
     # Patients with ONS-registered death
-    died_ons_covid_flag_any=patients.with_these_codes_on_death_certificate(
-        covid_codelist,  # imported from codelists.py
-        returning="binary_flag",
-        between=["index_date", end_date],
-        match_only_underlying_cause=False,  # boolean for indicating if filters
-        # results to only specified cause of death
-        return_expectations={
-            "rate": "exponential_increase",
-            "incidence": 0.05,
-        },
-    ),
-    died_ons_covid_flag_any_date=patients.with_these_codes_on_death_certificate(
+    died_ons_covid_any_date=patients.with_these_codes_on_death_certificate(
         covid_codelist,  # imported from codelists.py
         returning="date_of_death",
         between=["index_date", end_date],

--- a/analysis/study_definition_wave2.py
+++ b/analysis/study_definition_wave2.py
@@ -560,7 +560,7 @@ study = StudyDefinition(
                 diabetes AND hba1c_category = "2"
                 """,
             "3": """
-                diabetes AND hba1c_category = "3"
+                diabetes AND hba1c_category = "0"
                 """
         }, return_expectations={
                                 "category": {
@@ -700,7 +700,7 @@ study = StudyDefinition(
     # egfr<60 BUT since first rule is >45, we're not sure it actually is >45.
     # Restricting to those not '>', '>=', '~' or '=' (like is done for category
     # 5) is therefore not enough, and we need to be stricter by limiting to
-    # '='. The only comparator that can be used AND fullfils both rules, 
+    # '='. The only comparator that can be used AND fullfils both rules,
     # is '='.
     egfr_category=patients.categorised_as(
         {

--- a/analysis/study_definition_wave3.py
+++ b/analysis/study_definition_wave3.py
@@ -895,18 +895,7 @@ study = StudyDefinition(
     ),
     # OUTCOMES
     # Patients with ONS-registered death
-    died_ons_covid_flag_any=patients.with_these_codes_on_death_certificate(
-        covid_codelist,  # imported from codelists.py
-        returning="binary_flag",
-        between=["index_date", end_date],
-        match_only_underlying_cause=False,  # boolean for indicating if filters
-        # results to only specified cause of death
-        return_expectations={
-            "rate": "exponential_increase",
-            "incidence": 0.05,
-        },
-    ),
-    died_ons_covid_flag_any_date=patients.with_these_codes_on_death_certificate(
+    died_ons_covid_any_date=patients.with_these_codes_on_death_certificate(
         covid_codelist,  # imported from codelists.py
         returning="date_of_death",
         between=["index_date", end_date],

--- a/analysis/study_definition_wave3.py
+++ b/analysis/study_definition_wave3.py
@@ -560,7 +560,7 @@ study = StudyDefinition(
                 diabetes AND hba1c_category = "2"
                 """,
             "3": """
-                diabetes AND hba1c_category = "3"
+                diabetes AND hba1c_category = "0"
                 """
         }, return_expectations={
                                 "category": {
@@ -700,7 +700,7 @@ study = StudyDefinition(
     # egfr<60 BUT since first rule is >45, we're not sure it actually is >45.
     # Restricting to those not '>', '>=', '~' or '=' (like is done for category
     # 5) is therefore not enough, and we need to be stricter by limiting to
-    # '='. The only comparator that can be used AND fullfils both rules, 
+    # '='. The only comparator that can be used AND fullfils both rules,
     # is '='.
     egfr_category=patients.categorised_as(
         {

--- a/analysis/utils/extract_data.R
+++ b/analysis/utils/extract_data.R
@@ -45,8 +45,7 @@ extract_data <- function(file_name) {
            config$demographics,
            # comorbidities
            config$comorbidities,
-           died_ons_covid_flag_any,
-           died_ons_covid_flag_any_date,
+           died_ons_covid_any_date,
            died_any_date) %>%
     mutate(patient_id = as.integer(patient_id),
            age = as.numeric(patient_id),
@@ -54,8 +53,7 @@ extract_data <- function(file_name) {
            across(c(agegroup, sex, config$demographics), as.character),
            across(all_of(comorbidities_multilevel_vctr), as.character),
            across(all_of(comorbidities_binary_vctr), as.logical),
-           died_ons_covid_flag_any = as.logical(died_ons_covid_flag_any),
-           died_ons_covid_flag_any_date = as_date(died_ons_covid_flag_any_date),
+           died_ons_covid_any_date = as_date(died_ons_covid_any_date),
            died_any_date = as_date(died_any_date))
   data_extracted
 }

--- a/analysis/utils/model_coxph.R
+++ b/analysis/utils/model_coxph.R
@@ -87,7 +87,7 @@ coxmodel <- function(data, variable) {
     log_file[, 3] <- NA_character_
     # if warning, save warning
     if(length(model()$warnings) != 0){
-      log_file[, 2] <- model()$warnings
+      log_file[, 2] <- paste(model()$warnings, collapse = '; ')
     } else log_file[, 2] <- NA_character_
     # Test PH assumption
     # returns function test_ph() with components result and error
@@ -114,7 +114,7 @@ coxmodel <- function(data, variable) {
     out[, 4:5] <- confint(model()$result)[selection,] %>% exp()
     # save global test in 'out_ph'
     out_ph[1, 2] <- test_ph()$result[n_vars + 1, 3]
-  } else log_file[, 3] <- model()$messages
+  } else log_file[, 3] <- model()$error
   list(effect_estimates = out, 
        ph_test = out_ph,
        log_file = log_file)

--- a/analysis/utils/process_data.R
+++ b/analysis/utils/process_data.R
@@ -131,12 +131,17 @@ process_data <- function(data_extracted, waves_dates_list) {
         organ_kidney_transplant == "Organ" ~ "Other organ transplant"
       ), 
       
+      died_ons_covid_flag_any = case_when(
+        !is.na(died_ons_covid_any_date) ~ TRUE,
+        TRUE ~ FALSE
+      ),
+      
       # died from covid (1); died from other cause (2); 
       # alive at the end of study (0)
       status = fct_case_when(
-        !is.na(died_ons_covid_flag_any_date) ~ "1",
+        !is.na(died_ons_covid_any_date) ~ "1",
         # died from other cause
-        (is.na(died_ons_covid_flag_any_date) &
+        (is.na(died_ons_covid_any_date) &
            !is.na(died_any_date)) ~ "2",
         TRUE ~ "0"
       )
@@ -148,7 +153,7 @@ process_data <- function(data_extracted, waves_dates_list) {
       fu = case_when(
         status == "1" ~
           difftime(
-            died_ons_covid_flag_any_date,
+            died_ons_covid_any_date,
             waves_dates_list$start_date,
             tz = "UTC"
           ),


### PR DESCRIPTION
This PR:
- Restricts data extraction to extraction of date of death only io date of death AND a binary flag indicating death. 
- Fix error in `diabetes_controlled`(it seemed as if everyone had a recent measure of hb1ac, due to a coding error, which has been corrected now). 