### PR TITLE
Redact mortality rates

### DIFF
--- a/analysis/crude_rates_standardise.R
+++ b/analysis/crude_rates_standardise.R
@@ -15,9 +15,9 @@ library(dplyr)
 
 # Import rates ---
 crude_rates <- 
-  read_csv(file = here("output", "joined", "measure_crude_mortality_rate.csv"))
+  read_csv(file = here("output", "rates", "redacted", "crude_redacted.csv"))
 crude_rates_per_agegroup <-
-  read_csv(file = here("output", "joined", "measure_age_mortality_rate.csv"))
+  read_csv(file = here("output", "rates", "redacted", "age_redacted.csv"))
 
 # Standardise rates ---
 ## Add column containing number of days in every month
@@ -38,9 +38,10 @@ crude_rates_per_agegroup <-
   select(date, sex, agegroup, std_value)
 
 # Save output ---
-output_dir <- here("output", "rates")
+ifelse(!dir.exists(here("output", "rates")), dir.create(output_dir), FALSE)
+output_dir <- here("output", "rates", "standardised")
 ifelse(!dir.exists(output_dir), dir.create(output_dir), FALSE)
 write_csv(x = crude_rates, 
-          path = paste0(output_dir, "/crude_monthly_std.csv"))
+          path = paste0(output_dir, "/crude_std.csv"))
 write_csv(x = crude_rates_per_agegroup, 
-         path = paste0(output_dir, "/crude_per_agegroup_monthly_std.csv"))
+          path = paste0(output_dir, "/crude_per_agegroup_std.csv"))

--- a/analysis/crude_rates_standardise.R
+++ b/analysis/crude_rates_standardise.R
@@ -38,7 +38,8 @@ crude_rates_per_agegroup <-
   select(date, sex, agegroup, std_value)
 
 # Save output ---
-ifelse(!dir.exists(here("output", "rates")), dir.create(output_dir), FALSE)
+ifelse(!dir.exists(here("output", "rates")), 
+       dir.create(here("output", "rates")), FALSE)
 output_dir <- here("output", "rates", "standardised")
 ifelse(!dir.exists(output_dir), dir.create(output_dir), FALSE)
 write_csv(x = crude_rates, 

--- a/analysis/crude_rates_visualise.R
+++ b/analysis/crude_rates_visualise.R
@@ -19,10 +19,10 @@ source(here("analysis", "utils", "plot_rates.R"))
 
 # Import rates ---
 crude_rates <- 
-  read_csv(file = here("output", "rates", "crude_monthly_std.csv"),
+  read_csv(file = here("output", "rates", "standardised", "crude_std.csv"),
            col_types = cols("D", "d"))
 crude_rates_per_agegroup <-
-  read_csv(file = here("output", "rates", "crude_per_agegroup_monthly_std.csv"),
+  read_csv(file = here("output", "rates", "standardised", "crude_per_agegroup_std.csv"),
            col_types = cols("D", "f", "f", "d"))
 
 # Plot rates ---

--- a/analysis/subgroups_rates_standardise.R
+++ b/analysis/subgroups_rates_standardise.R
@@ -30,8 +30,9 @@ source(here("analysis", "utils", "dsr.R"))
 subgroups_vctr <- c("sex", config$demographics, config$comorbidities)
 subgroups_rates <- 
   map(.x = here("output", 
-                "joined",
-                paste0("measure_", subgroups_vctr,"_mortality_rate.csv")),
+                "rates",
+                "redacted",
+                paste0(subgroups_vctr,"_redacted.csv")),
       .f = ~ read_csv(file = .x))
 names(subgroups_rates) <- subgroups_vctr # used in imap and iwalk (.y)
 ## European Standard population
@@ -95,8 +96,9 @@ subgroups_rates <-
                    .groups = "drop"))
 
 # Save output ---
-output_dir <- here("output", "rates")
+ifelse(!dir.exists(here("output", "rates")), dir.create(output_dir), FALSE)
+output_dir <- here("output", "rates", "standardised")
 ifelse(!dir.exists(output_dir), dir.create(output_dir), FALSE)
 iwalk(.x = subgroups_rates,
       .f = ~ write_csv(x = .x,
-                       path = paste0(output_dir, "/", .y, "_monthly_std.csv")))
+                       path = paste0(output_dir, "/", .y, "_std.csv")))

--- a/analysis/subgroups_rates_standardise.R
+++ b/analysis/subgroups_rates_standardise.R
@@ -96,7 +96,8 @@ subgroups_rates <-
                    .groups = "drop"))
 
 # Save output ---
-ifelse(!dir.exists(here("output", "rates")), dir.create(output_dir), FALSE)
+ifelse(!dir.exists(here("output", "rates")), 
+       dir.create(here("output", "rates")), FALSE)
 output_dir <- here("output", "rates", "standardised")
 ifelse(!dir.exists(output_dir), dir.create(output_dir), FALSE)
 iwalk(.x = subgroups_rates,

--- a/analysis/subgroups_rates_visualise.R
+++ b/analysis/subgroups_rates_visualise.R
@@ -31,7 +31,8 @@ source(here("analysis", "utils", "plot_rates.R"))
 ## Import mortality rates for sex:
 sex_rates_std <- read_csv(file = here("output", 
                                       "rates",
-                                      "sex_monthly_std.csv"),
+                                      "standardised",
+                                      "sex_std.csv"),
                           col_types = cols("D", "f", "d", "d"))
 # Import the rest of the mortality rates:
 subgroups_vctr <- c(config$demographics, config$comorbidities)

--- a/analysis/subgroups_ratios.R
+++ b/analysis/subgroups_ratios.R
@@ -26,7 +26,8 @@ subgroups_vctr <- c(config$demographics, config$comorbidities)
 ## Import mortality rates for sex:
 sex_rates_std <- read_csv(file = here("output", 
                                       "rates",
-                                      "sex_monthly_std.csv"),
+                                      "standardised",
+                                      "sex_std.csv"),
                           col_types = cols("D", "f", "d", "d"))
 ## Import the rest of the mortality rates
 subgroups_rates_std <- 

--- a/analysis/utils/process_rates.R
+++ b/analysis/utils/process_rates.R
@@ -27,7 +27,8 @@ subgroups_rates_std <-
   map(.x = subgroups_vctr,
       .f = ~ read_csv(file = here("output", 
                                   "rates",
-                                  paste0(.x,"_monthly_std.csv")),
+                                  "standardised",
+                                  paste0(.x,"_std.csv")),
                       col_types = cols("D", "f", "f", "d", "d")))
 names(subgroups_rates_std) <- subgroups_vctr
 

--- a/analysis/utils/redact_rates.R
+++ b/analysis/utils/redact_rates.R
@@ -66,6 +66,7 @@ rates <-
       .f = ~ redact_file(file = .x))
 
 # Save output ---
+ifelse(!dir.exists(here("output", "rates")), dir.create(output_dir), FALSE)
 output_dir <- here("output", "rates", "redacted")
 ifelse(!dir.exists(output_dir), dir.create(output_dir), FALSE)
 iwalk(.x = rates,

--- a/analysis/utils/redact_rates.R
+++ b/analysis/utils/redact_rates.R
@@ -1,0 +1,73 @@
+## ###########################################################
+
+##  This script:
+## - Imports the mortality rates (outputted by the measures framework)
+## - Redacts low numbers
+
+## linda.nab@thedatalab.com - 20220524
+## ###########################################################
+
+# Load libraries & functions ---
+library(here)
+library(readr)
+library(purrr)
+library(dplyr)
+library(lubridate)
+library(jsonlite)
+## Load json file listing demographics and comorbidities
+config <- fromJSON(here("analysis", "config.json"))
+## Function that redacts counts smaller than five and sets value equal to 0
+redact_file <- function(file){
+  file <- 
+    file %>%
+    mutate(
+      died_ons_covid_flag_any = case_when(died_ons_covid_flag_any <= 5 ~ 0,
+                                          TRUE ~ died_ons_covid_flag_any)
+    ) %>%
+    mutate(value = case_when(died_ons_covid_flag_any <= 5 ~ 0,
+                             TRUE ~ value))
+}
+
+# Load rates ---
+## Create vector containing the demographics and comorbidities
+subgroups_vctr <- c(config$demographics, config$comorbidities)
+# Import the crude mortality rates:
+# these are imported separately from the subgroups rates as the file 
+# has one column less than the csv for age /sex
+crude_rates <- 
+  read_csv(file = here("output",
+                       "joined",
+                       "measure_crude_mortality_rate.csv"),
+           col_types = cols("d", "d", "d", "D"))
+# Import the mortality rates for age and sex:
+# these are imported separately from the subgroups rates as the file 
+# has one column less than the med cond
+age_sex_rates <- 
+  map(.x = c("age", "sex"),
+      .f = ~ read_csv(file = here("output", 
+                                  "joined",
+                                  paste0("measure_", .x,"_mortality_rate.csv")),
+                      col_types = cols("f", "f", "d", "d", "d", "D")))
+names(age_sex_rates) <- c("age", "sex")
+# Import the mortality rates of the subgroups:
+subgroups_rates <- 
+  map(.x = subgroups_vctr,
+      .f = ~ read_csv(file = here("output", 
+                                  "joined",
+                                  paste0("measure_", .x,"_mortality_rate.csv")),
+                      col_types = cols("f", "f", "f", "d", "d", "d", "D")))
+names(subgroups_rates) <- subgroups_vctr
+# Make one big list
+rates <- c(crude = list(crude_rates), age_sex_rates, subgroups_rates)
+
+# Redact counts ---
+rates <-
+  map(.x = rates,
+      .f = ~ redact_file(file = .x))
+
+# Save output ---
+output_dir <- here("output", "rates", "redacted")
+ifelse(!dir.exists(output_dir), dir.create(output_dir), FALSE)
+iwalk(.x = rates,
+      .f = ~ write_csv(x = .x,
+                       path = paste0(output_dir, "/", .y, "_redacted.csv")))

--- a/analysis/utils/redact_rates.R
+++ b/analysis/utils/redact_rates.R
@@ -66,7 +66,8 @@ rates <-
       .f = ~ redact_file(file = .x))
 
 # Save output ---
-ifelse(!dir.exists(here("output", "rates")), dir.create(output_dir), FALSE)
+ifelse(!dir.exists(here("output", "rates")), 
+       dir.create(here("output", "rates")), FALSE)
 output_dir <- here("output", "rates", "redacted")
 ifelse(!dir.exists(output_dir), dir.create(output_dir), FALSE)
 iwalk(.x = rates,

--- a/project.yaml
+++ b/project.yaml
@@ -52,21 +52,29 @@ actions:
       moderately_sensitive:
         measure: output/joined/measure_*_mortality_rate.csv
 
-# Standardise crude mortality rate
-  standardise_crude_rates:
-    run: r:latest analysis/crude_rates_standardise.R
+# Redact rates
+  redact_rates:
+    run: r:latest analysis/utils/redact_rates.R
     needs: [calculate_measures]
     outputs:
       moderately_sensitive:
-        csvs: output/rates/crude_*monthly_std.csv 
+        csvs: output/rates/redacted/*_redacted.csv       
+
+# Standardise crude mortality rate
+  standardise_crude_rates:
+    run: r:latest analysis/crude_rates_standardise.R
+    needs: [redact_rates]
+    outputs:
+      moderately_sensitive:
+        csvs: output/rates/standardised/crude_*std.csv 
 
 # Standardise subgroup specific mortality rates
   standardise_subgroup_rates:
     run: r:latest analysis/subgroups_rates_standardise.R
-    needs: [calculate_measures]
+    needs: [redact_rates]
     outputs:
       moderately_sensitive:
-        csvs: output/rates/*_monthly_std.csv
+        csvs: output/rates/standardised/*_std.csv
 
 # Process subgroup specific mortality rates
   process_subgroup_rates:


### PR DESCRIPTION
All counts lower than five and accompanying 'value' in the output of the measures framework (saved in /output/joined/measure_*.csv) are now redacted (redacted files are saved in /output/rates/redacted/*_redacted.csv).